### PR TITLE
DATABASE_URL을 DB_URL로 강제 override

### DIFF
--- a/src/main/java/com/etl/sfdc/ETLApplication.java
+++ b/src/main/java/com/etl/sfdc/ETLApplication.java
@@ -10,6 +10,24 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class ETLApplication {
 
     public static void main(String[] args) {
+
+        // Heroku가 자동으로 주입하는 Heroku PG의 DATABASE_URL이 자꾸 DB로 들어와서 에러냄.
+        // 이를 덮어쓰기 위해서 DATABASE_URL을 DB_URL로 강제 override.
+
+        String dbUrl = System.getenv("DB_URL");
+        String dbUsername = System.getenv("DB_USERNAME");
+        String dbPassword = System.getenv("DB_PASSWORD");
+
+        if (dbUrl != null) {
+            System.setProperty("spring.datasource.url", dbUrl);
+        }
+        if (dbUsername != null) {
+            System.setProperty("spring.datasource.username", dbUsername);
+        }
+        if (dbPassword != null) {
+            System.setProperty("spring.datasource.password", dbPassword);
+        }
+
         SpringApplication.run(ETLApplication.class, args);
     }
 

--- a/src/main/java/com/etl/sfdc/user/controller/UserController.java
+++ b/src/main/java/com/etl/sfdc/user/controller/UserController.java
@@ -45,7 +45,6 @@ public class UserController {
             bindingResult.rejectValue("password2", "passwordInCorrect", "2개의 패스워드가 일치하지 않습니다.");
             return "signup_form";
         }*/
-        //TEST 삭제 필요.확인용 yk.kim
 
         userService.create(userCreateForm.getUsername(),
                 userCreateForm.getEmail(), userCreateForm.getPassword1(), userCreateForm.getDescription());

--- a/src/main/java/com/etl/sfdc/user/model/service/UserSecurityServiceImpl.java
+++ b/src/main/java/com/etl/sfdc/user/model/service/UserSecurityServiceImpl.java
@@ -33,7 +33,7 @@ public class UserSecurityServiceImpl implements UserSecurityService, UserDetails
             throw new UsernameNotFoundException("사용자를 찾을수 없습니다.");
         }
 
-        // 일단 한성진 유저인 경우레 어드민 권한 부여
+        // 일단 한성진 유저인 경우에 어드민 권한 부여
         List<GrantedAuthority> authorities = new ArrayList<>();
         if ("한성진".equals(username)) {
             authorities.add(new SimpleGrantedAuthority(UserRole.ADMIN.getValue()));


### PR DESCRIPTION
Heroku가 자동으로 주입하는 Heroku PG의 DATABASE_URL이 자꾸 DB로 들어와서 에러냄.
마리아 DB에서 사용자 로그인 정보 찾아야 하는데
자꾸 Heroku Postgres DB로 납치함.
이를 방지하기 위해 DATABASE_URL(Heroku PG 기본 환경변수)을 DB_URL로 강제 override.